### PR TITLE
Avoid temporary file conflicts.

### DIFF
--- a/src/lib/EcomDev/LayoutCompiler/Compiler.php
+++ b/src/lib/EcomDev/LayoutCompiler/Compiler.php
@@ -146,7 +146,7 @@ class EcomDev_LayoutCompiler_Compiler
                     mkdir($path, 0755, true);
                 }
 
-                $tmpFile = $path . DIRECTORY_SEPARATOR . uniqid('tempfile');
+                $tmpFile = $path . DIRECTORY_SEPARATOR . uniqid('tempfile', TRUE);
                 $content = sprintf(
                     "<?php %s",
                     implode(

--- a/src/lib/EcomDev/LayoutCompiler/Index.php
+++ b/src/lib/EcomDev/LayoutCompiler/Index.php
@@ -202,7 +202,7 @@ class EcomDev_LayoutCompiler_Index
             mkdir($this->getSavePath(), 0755, true);
         }
 
-        $tmpFile = $this->getSavePath() . DIRECTORY_SEPARATOR . uniqid('tempfile');
+        $tmpFile = $this->getSavePath() . DIRECTORY_SEPARATOR . uniqid('tempfile', TRUE);
         $filePath = $this->getIndexFileName($parameters);
         file_put_contents($tmpFile, "<?php \n" . implode("\n", $lines));
         rename($tmpFile, $filePath);


### PR DESCRIPTION
After deploying this module I got a few errors logged like this:

> PHP Parse error:  syntax error, unexpected ')' in /var/www/XXX/var/ecomdev/layoutcompiler/file_base_default_layout_XXX_70b676a8fd96464e6cb4b202299cc6c8_checkout_cart_index.php on line 3

And:

> Warning: rename(/var/www/XXX/var/ecomdev/layoutcompiler/tempfile57b4bbc0e6d30,/var/www/XXX/var/ecomdev/layoutcompiler/file_base_default_layout_page_03ad64b8e89c831a99ad8f100125e119_default.php): No such file or directory  in /var/www/XXX/.modman/EcomDev_LayoutCompiler/src/lib/EcomDev/LayoutCompiler/Compiler.php on line 166

I believe these are due to the use of uniqid for deriving the temp file name and resulting in two processes writing to the same temp files. The uniqid function is just a compact form of the current microsecond so is similar in uniqueness to microtime(true) (it is a terrible name for this function). Setting the second parameter causes there to actually be some randomness involved.
